### PR TITLE
Disabled building of the app for non-Win32 platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ elseif(("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" ST
     set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS} -O2")
 endif()
 
-add_subdirectory(
-    app/diff-wave
-)
+if (WIN32)
+    add_subdirectory(
+        app/diff-wave
+    )
+endif(WIN32)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,15 +20,15 @@ set(WAVE_SOURCES
 set(WAVE_SOVERSION  0)
 set(WAVE_VERSION    0.1.0)
 
-include_directories(
-    ${WAVE_INCLUDES}
-)
-
 add_library(${PROJECT_NAME} SHARED ${WAVE_SOURCES})
 set_target_properties(${PROJECT_NAME}
     PROPERTIES
     VERSION                 ${WAVE_VERSION}
     SOVERSION               ${WAVE_SOVERSION}
+)
+target_include_directories(
+    ${PROJECT_NAME}
+    PUBLIC ${WAVE_INCLUDES}
 )
 
 add_library(${PROJECT_NAME}_static STATIC ${WAVE_SOURCES})
@@ -36,6 +36,10 @@ set_target_properties(${PROJECT_NAME}_static
     PROPERTIES
     VERSION                 ${WAVE_VERSION}
     SOVERSION               ${WAVE_SOVERSION}
+)
+target_include_directories(
+    ${PROJECT_NAME}_static
+    PUBLIC ${WAVE_INCLUDES}
 )
 
 install(

--- a/include/wave.h
+++ b/include/wave.h
@@ -20,7 +20,7 @@
  *
  */
 
-#ifdef __cpluscplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 

--- a/include/wave_defs.h
+++ b/include/wave_defs.h
@@ -12,7 +12,6 @@ extern "C" {
 #define WAVE_FORMAT_MULAW           0x0007
 #define WAVE_FORMAT_EXTENSIBLE      0xfffe
 
-typedef enum _WaveError WaveError;
 enum _WaveError {
     WAVE_SUCCESS,           /* no error */
     WAVE_ERROR_FORMAT,      /* not a wave file or unsupported wave format */
@@ -21,6 +20,7 @@ enum _WaveError {
     WAVE_ERROR_STDIO,       /* error when {wave} called a stdio function */
     WAVE_ERROR_PARAM,       /* incorrect parameter passed to the API function */
 };
+typedef enum _WaveError WaveError;
 
 typedef struct _WaveFile WaveFile;
 


### PR DESCRIPTION
The app is Win32-only (the diff_dir function is only implemented if _WIN32 is defined).