### PR TITLE
Remove non-existing files from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,12 +17,10 @@ set(includes
 
 set(public_headers
   include/wav.h
-  include/wav_defs.h
 )
 
 set(sources
   src/wav.c
-  src/wav_priv.h
 )
 
 add_library(${PROJECT_NAME} ${sources})


### PR DESCRIPTION
Hi, this PR fixes cmake build. Those two files were removed in 476bb4ce2bea63c10fef88721b10f3b508439a0d.