### PR TITLE
Support for STM32 MCUs with Cortex-M7 Cores

### DIFF
--- a/src/wav.c
+++ b/src/wav.c
@@ -6,7 +6,7 @@
 
 #include "wav.h"
 
-#if defined(__x86_64) || defined(__amd64) || defined(__i386__) || defined(__x86_64__) || defined(__LITTLE_ENDIAN__)
+#if defined(__x86_64) || defined(__amd64) || defined(__i386__) || defined(__x86_64__) || defined(__LITTLE_ENDIAN__) || defined(CORE_CM7)
 #define WAV_ENDIAN_LITTLE 1
 #elif defined(__BIG_ENDIAN__)
 #define WAV_ENDIAN_BIG 1


### PR DESCRIPTION
Adds support for STM32 MCUs with Cortex-M7 cores. No other changes are required.

For using this library, it's required to have implemented _open / _write / _read / _lseek syscalls implemented, but that's out of this library scope.