### PR TITLE
Improved endianess check, fixed compiler warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-This fork adds build support for ARM platforms
---
 # libwav
 
 libwav is a simple and tiny C library for reading or writing PCM wave (.wav)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+---
+*This fork adds build support for ARM platforms and fixes compiling issues*
+---
+
 # libwav
 
 libwav is a simple and tiny C library for reading or writing PCM wave (.wav)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ---
 
-*This fork adds build support for ARM platforms and fixes compiling issues*
+This fork adds build support for ARM platforms and fixes compiling issues
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Build support for ARM platforms added in th fork
+--
 # libwav
 
 libwav is a simple and tiny C library for reading or writing PCM wave (.wav)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 ---
+
 *This fork adds build support for ARM platforms and fixes compiling issues*
+
 ---
 
 # libwav

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Build support for ARM platforms added in th fork
+This fork adds build support for ARM platforms
 --
 # libwav
 

--- a/include/wav.h
+++ b/include/wav.h
@@ -8,7 +8,6 @@
  *
  *   - formats other than PCM, IEEE float and log-PCM
  *   - extra chunks after the data chunk
- *   - big endian platforms (might be supported in the future)
  */
 
 #ifndef __WAV_H__

--- a/include/wav.h
+++ b/include/wav.h
@@ -20,6 +20,8 @@ extern "C" {
 
 #include <stdarg.h>
 #include <stddef.h>
+#include <stdint.h>
+#include <stdbool.h>
 
 #if !defined(_MSC_VER) || _MSC_VER >= 1800
 #define WAV_INLINE static inline
@@ -29,25 +31,6 @@ extern "C" {
 #define WAV_INLINE static __inline
 #define WAV_CONST
 #define WAV_RESTRICT __restrict
-#endif
-
-#if defined(__APPLE__) || defined(_MSC_VER)
-typedef long long           WavI64;
-typedef unsigned long long  WavU64;
-typedef long long           WavIntPtr;
-typedef unsigned long long  WavUIntPtr;
-#else
-#if defined(_WIN64) || defined(__x86_64) || defined(__amd64)
-typedef long                WavI64;
-typedef unsigned long       WavU64;
-typedef long                WavIntPtr;
-typedef unsigned long       WavUIntPtr;
-#else
-typedef long long           WavI64;
-typedef unsigned long long  WavU64;
-typedef int                 WavIntPtr;
-typedef unsigned int        WavUIntPtr;
-#endif
 #endif
 
 #if defined(__cplusplus) && __cplusplus >= 201103L
@@ -60,13 +43,16 @@ typedef unsigned int        WavUIntPtr;
 #define WAV_THREAD_LOCAL __thread
 #endif
 
-typedef int                 WavBool;
-typedef signed char         WavI8;
-typedef unsigned char       WavU8;
-typedef short               WavI16;
-typedef unsigned short      WavU16;
-typedef int                 WavI32;
-typedef unsigned int        WavU32;
+typedef bool       WavBool;
+typedef int8_t     WavI8;
+typedef uint8_t    WavU8;
+typedef int16_t    WavI16;
+typedef uint16_t   WavU16;
+typedef int32_t    WavI32;
+typedef uint32_t   WavU32;
+typedef int64_t    WavI64;
+typedef uint64_t   WavU64;
+typedef uintptr_t  WavUIntPtr;
 
 enum {
     WAV_FALSE,

--- a/src/wav.c
+++ b/src/wav.c
@@ -6,7 +6,7 @@
 
 #include "wav.h"
 
-#if defined(__x86_64) || defined(__amd64) || defined(__i386__) || defined(__x86_64__) || defined(__LITTLE_ENDIAN__) || defined(CORE_CM7)
+#if defined(__x86_64) || defined(__amd64) || defined(__i386__) || defined(__x86_64__) || defined(__LITTLE_ENDIAN__) || defined(CORE_CM7) || defined(__arm__)
 #define WAV_ENDIAN_LITTLE 1
 #elif defined(__BIG_ENDIAN__)
 #define WAV_ENDIAN_BIG 1

--- a/src/wav.c
+++ b/src/wav.c
@@ -6,10 +6,11 @@
 
 #include "wav.h"
 
-#if defined(__x86_64) || defined(__amd64) || defined(__i386__) || defined(__x86_64__) || defined(__LITTLE_ENDIAN__) || defined(CORE_CM7) || defined(__arm__)
+#if defined(__x86_64) || defined(__amd64) || defined(__i386__) || defined(__x86_64__) || defined(__LITTLE_ENDIAN__) || defined(CORE_CM7) || \
+(defined(__BYTE_ORDER__) && (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__))
 #define WAV_ENDIAN_LITTLE 1
 #elif defined(__BIG_ENDIAN__)
-#define WAV_ENDIAN_BIG 1
+#define WAV_ENDIAN_LITTLE 0
 #endif
 
 #if WAV_ENDIAN_LITTLE
@@ -18,9 +19,7 @@
 #define WAV_FACT_CHUNK_ID       ((WavU32)'tcaf')
 #define WAV_DATA_CHUNK_ID       ((WavU32)'atad')
 #define WAV_WAVE_ID             ((WavU32)'EVAW')
-#endif
-
-#if WAV_ENDIAN_BIG
+#else
 #define WAV_RIFF_CHUNK_ID       ((WavU32)'RIFF')
 #define WAV_FORMAT_CHUNK_ID     ((WavU32)'fmt ')
 #define WAV_FACT_CHUNK_ID       ((WavU32)'fact')


### PR DESCRIPTION
- `__BYTE_ORDER__` evaluated to also work with gcc ARM (cross) compiler, for example
- Usage of preprocessor macros improved; could now be compiled w/o warnings with '-Wundef'
- Fixed compiler warnings seen on Windows/MinGW by using stdint types:
wav.c:434:108: warning: cast from pointer to integer of different size
[-Wpointer-to-int-cast]
     self->format_chunk.header.size              =
(WavU32)((WavUIntPtr)&self->format_chunk.body.ext_size -
(WavUIntPtr)&self->format_chunk.body);
^
- Obsolete comment removed